### PR TITLE
Add support for file watching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ lightning_css-*.tar
 # Bundled assets
 priv/static
 !priv/static/.gitkeep
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ config :lightning_css,
   version: "1.22.0",
   dev: [
     args: ~w(assets/foo.css --bundle --output-dir=static),
-    watch: "assets/**/*.css",
+    watch_files: "assets/**/*.css",
     cd: Path.expand("../priv", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]
@@ -38,7 +38,7 @@ config :lightning_css,
 - **version:** Indicates the version that the package will download and use. When absent, it defaults to the value of `@latest_version` at [`lib/lightning_css.ex`](./lib/lightning_css.ex).
 - **profiles:** Additional keys in the configuration keyword list represent profiles. Profiles are a combination of attributes the Lightning CSS can be executed with. You can indicate the profile to use when invoking the Mix task by using the `--profile` flag, for example `mix lightning_css --profile dev`. A profile is represented by a keyword list with the following attributes:
   - **args:** An list of strings representing the arguments that will be passed to the Lightning CSS executable.
-  - **watch (optional):** A glob pattern to enable file-watching. When present, the Mix task locks the process and re-runs Lightning CSS when files change.
+  - **watch_files (optional):** A glob pattern that will be used when Lightning CSS is invoked with `--watch` to match the file changes against it.
   - **cd (optional):** The directory from where Lightning CSS is executed. When absent, it defaults to the project's root directory.
   - **env (optional):** A set of environment variables to make available to the Lightning CSS process.
 
@@ -53,7 +53,7 @@ config :my_app, MyAppWeb.Endpoint,
   # ...other attributes
   watchers: [
     # :default is the name of the profile. Update it to match yours.
-    css: {LightningCSS, :install_and_run, [:default, ~w()]}
+    css: {LightningCSS, :install_and_run, [:default, ~w(), watch: true]}
   ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,64 @@ def deps do
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/lightningcss>.
+## Usage
 
+After installing the package, you'll have to configure it in your project:
+
+```elixir
+# config/config.exs
+config :lightning_css,
+  version: "1.22.0",
+  dev: [
+    args: ~w(assets/foo.css --bundle --output-dir=static),
+    watch: "assets/**/*.css",
+    cd: Path.expand("../priv", __DIR__),
+    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+  ]
+```
+
+### Configuration options
+
+- **version:** Indicates the version that the package will download and use. When absent, it defaults to the value of `@latest_version` at [`lib/lightning_css.ex`](./lib/lightning_css.ex).
+- **profiles:** Additional keys in the configuration keyword list represent profiles. Profiles are a combination of attributes the Lightning CSS can be executed with. You can indicate the profile to use when invoking the Mix task by using the `--profile` flag, for example `mix lightning_css --profile dev`. A profile is represented by a keyword list with the following attributes:
+  - **args:** An list of strings representing the arguments that will be passed to the Lightning CSS executable.
+  - **watch (optional):** A glob pattern to enable file-watching. When present, the Mix task locks the process and re-runs Lightning CSS when files change.
+  - **cd (optional):** The directory from where Lightning CSS is executed. When absent, it defaults to the project's root directory.
+  - **env (optional):** A set of environment variables to make available to the Lightning CSS process.
+
+### Phoenix
+
+If you are using the Phoenix framework, we recommend doing an integration similar to the one Phoenix proposes by default for Tailwind and ESBuild.
+
+After adding the dependency and configuring it as described above with at least one profile, adjust your app's endpoint configuration to add a new watcher:
+
+```elixir
+config :my_app, MyAppWeb.Endpoint,
+  # ...other attributes
+  watchers: [
+    # :default is the name of the profile. Update it to match yours.
+    css: {LightningCSS, :install_and_run, [:default, ~w()]}
+  ]
+```
+
+Then update the `aliases` of your project's `mix.exs` file:
+
+```elixir
+defp aliases do
+  [
+    # ...other aliases
+    "assets.setup": [
+      # ...other assets.setup tasks
+      "lightning_css.install --if-missing"
+    ],
+    "assets.build": [
+      # ...other assets.build tasks
+      "lightning_css default",
+    ],
+    "assets.deploy": [
+      # ...other deploy tasks
+      "lightning_css default",
+    ]
+  ]
+end
+```

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,7 @@ config :lightning_css,
   version: "1.22.0",
   dev: [
     args: ~w(assets/foo.css --bundle --output-dir=static),
-    watch: "assets/**/*.css",
+    watch_files: "assets/**/*.css",
     cd: Path.expand("../priv", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,7 @@ config :lightning_css,
   version: "1.22.0",
   dev: [
     args: ~w(assets/foo.css --bundle --output-dir=static),
-    watch_files: "assets/**/*.css",
+    watch_files: "assets",
     cd: Path.expand("../priv", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,6 +4,7 @@ config :lightning_css,
   version: "1.22.0",
   dev: [
     args: ~w(assets/foo.css --bundle --output-dir=static),
+    watch: "assets/**/*.css",
     cd: Path.expand("../priv", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]

--- a/lib/lightning_css.ex
+++ b/lib/lightning_css.ex
@@ -129,7 +129,7 @@ defmodule LightningCSS do
   def run(profile, extra_args, opts) when is_atom(profile) and is_list(extra_args) do
     watch = opts |> Keyword.get(:watch, false)
 
-    id = ([profile] ++ extra_args ++ [watch]) |> Enum.map(&to_string/1) |> Enum.join("_") |> String.to_atom()
+    id = ([profile] ++ extra_args ++ [watch]) |> Enum.map_join("_", &to_string/1) |> String.to_atom()
 
     ref =
       __MODULE__.Supervisor
@@ -149,8 +149,8 @@ defmodule LightningCSS do
     receive do
       {:DOWN, ^ref, _, _, _} ->
         :ok
-      something ->
-        dbg(something)
+      _ ->
+        :ok
     end
     0
   end

--- a/lib/lightning_css/runner.ex
+++ b/lib/lightning_css/runner.ex
@@ -64,6 +64,17 @@ defmodule LightningCSS.Runner do
     send(gen_server_pid, {:lightning_css_exited, exit_status})
   end
 
+  def handle_info({:file_event, watcher_pid, {path, events}}, %{watcher_pid: watcher_pid}=state) do
+    Logger.info("File event #{inspect(events)} on #{path}")
+    # YOUR OWN LOGIC FOR PATH AND EVENTS
+    {:noreply, state}
+  end
+
+  def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid}=state) do
+    # YOUR OWN LOGIC WHEN MONITOR STOP
+    {:noreply, state}
+  end
+
   def handle_info({:lightning_css_exited, exit_status}, %{ watch: watch } = state) do
     case {watch, exit_status} do
       {true, 0} -> {:noreply, state }
@@ -87,15 +98,5 @@ defmodule LightningCSS.Runner do
 
   def terminate(_, _) do
     :ok
-  end
-
-  def handle_info({:file_event, watcher_pid, {path, events}}, %{watcher_pid: watcher_pid}=state) do
-    # YOUR OWN LOGIC FOR PATH AND EVENTS
-    {:noreply, state}
-  end
-
-  def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid}=state) do
-    # YOUR OWN LOGIC WHEN MONITOR STOP
-    {:noreply, state}
   end
 end

--- a/lib/lightning_css/runner.ex
+++ b/lib/lightning_css/runner.ex
@@ -1,4 +1,6 @@
 defmodule LightningCSS.Runner do
+  @moduledoc false
+
   use GenServer
   require Logger
 
@@ -13,7 +15,7 @@ defmodule LightningCSS.Runner do
   end
 
   @spec init(args :: init_args) :: {:ok, any()}
-  def init(%{ profile: profile, extra_args: _, watch: watch} = args) do
+  def init(%{profile: profile, extra_args: _, watch: watch} = args) do
     config = LightningCSS.config_for!(profile)
     cd = config |> Keyword.get(:cd, File.cwd!())
 
@@ -32,7 +34,7 @@ defmodule LightningCSS.Runner do
     gen_server_pid = self()
     args = args |> Map.put(:gen_server_pid, gen_server_pid)
 
-    %{ pid: process_pid } = Task.async(fn ->
+    %{pid: process_pid} = Task.async(fn ->
       Logger.info("Running Lightning CSS")
       __MODULE__.run_lightning_css(args)
     end)
@@ -42,7 +44,7 @@ defmodule LightningCSS.Runner do
     {:ok, args}
   end
 
-  def run_lightning_css(%{ config: config, extra_args: extra_args, cd: cd, gen_server_pid: gen_server_pid }) do
+  def run_lightning_css(%{config: config, extra_args: extra_args, cd: cd, gen_server_pid: gen_server_pid}) do
     args = config[:args] || []
 
     if args == [] and extra_args == [] do
@@ -66,7 +68,7 @@ defmodule LightningCSS.Runner do
   end
 
   def handle_info({:file_event, _watcher_pid, {_path, _events}}, state) do
-    %{ pid: process_pid } = Task.async(fn ->
+    %{pid: process_pid} = Task.async(fn ->
       Logger.info("Changes detected. Running Lightning CSS")
       __MODULE__.run_lightning_css(state)
     end)
@@ -74,11 +76,11 @@ defmodule LightningCSS.Runner do
     {:noreply, state}
   end
 
-  def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid}=state) do
+  def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid} = state) do
     {:stop, :normal, state}
   end
 
-  def handle_info({:lightning_css_exited, exit_status}, %{ watch: watch } = state) do
+  def handle_info({:lightning_css_exited, exit_status}, %{watch: watch} = state) do
     case {watch, exit_status} do
       {true, 0} -> {:noreply, state }
       {false, 0} -> {:stop, :normal, state}

--- a/lib/lightning_css/runner.ex
+++ b/lib/lightning_css/runner.ex
@@ -1,0 +1,101 @@
+defmodule LightningCSS.Runner do
+  use GenServer
+  require Logger
+
+  @type init_args :: %{
+    profile: atom(),
+    extra_args: [String.t()],
+    watch: boolean() }
+
+  @spec start_link(args :: init_args) :: GenServer.on_start()
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args)
+  end
+
+  @spec init(args :: init_args) :: {:ok, any()}
+  def init(%{ profile: profile, extra_args: _, watch: watch} = args) do
+    config = LightningCSS.config_for!(profile)
+    cd = config |> Keyword.get(:cd, File.cwd!())
+
+    case {watch, config[:watch_files]} do
+      {true, glob} when is_binary(glob) ->
+        dirs = Path.join(cd, glob)
+        Logger.info("Watching #{dirs}")
+        {:ok, watcher_pid} = FileSystem.start_link(dirs: [dirs])
+        FileSystem.subscribe(watcher_pid)
+      _ -> nil
+    end
+
+    args = args |> Map.put(:config, config) |> Map.put(:cd, cd)
+
+    gen_server_pid = self()
+    args = args |> Map.put(:gen_server_pid, gen_server_pid)
+
+    %{ pid: process_pid } = Task.async(fn ->
+      __MODULE__.run_lightning_css(args)
+    end)
+
+    args = args |> Map.put(:process_pid, process_pid)
+
+    {:ok, args}
+  end
+
+  def run_lightning_css(%{ config: config, extra_args: extra_args, cd: cd, gen_server_pid: gen_server_pid }) do
+    args = config[:args] || []
+
+    if args == [] and extra_args == [] do
+      raise "no arguments passed to lightning_css"
+    end
+
+    opts = [
+      cd: cd,
+      env: config[:env] || %{},
+      into: IO.stream(:stdio, :line),
+      stderr_to_stdout: true
+    ]
+
+    Logger.info("Running Lightning CSS")
+    command_string = ([Path.relative_to_cwd(LightningCSS.bin_path())] ++ args ++ extra_args) |> Enum.join(" ")
+    Logger.debug("Command: #{command_string}", opts)
+    exit_status = LightningCSS.bin_path()
+    |> System.cmd(args ++ extra_args, opts)
+    |> elem(1)
+    Logger.debug("Command completed with exit status #{exit_status}")
+    send(gen_server_pid, {:lightning_css_exited, exit_status})
+  end
+
+  def handle_info({:lightning_css_exited, exit_status}, %{ watch: watch } = state) do
+    case {watch, exit_status} do
+      {true, 0} -> {:noreply, state }
+      {false, 0} -> {:stop, :normal, state}
+      {true, status} ->
+        dbg("LightningCSS exited with status #{status}")
+        {:no_reply, state}
+      {false, status} ->
+        dbg("LightningCSS exited with status #{status}")
+        {:stop, {:error_and_no_watch, status}, state}
+    end
+  end
+
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+
+  def terminate(:normal, _state) do
+    :ok
+  end
+
+  def terminate(_, _) do
+    :ok
+  end
+
+  def handle_info({:file_event, watcher_pid, {path, events}}, %{watcher_pid: watcher_pid}=state) do
+    # YOUR OWN LOGIC FOR PATH AND EVENTS
+    {:noreply, state}
+  end
+
+  def handle_info({:file_event, watcher_pid, :stop}, %{watcher_pid: watcher_pid}=state) do
+    # YOUR OWN LOGIC WHEN MONITOR STOP
+    {:noreply, state}
+  end
+end

--- a/lib/mix/tasks/lightning_css.ex
+++ b/lib/mix/tasks/lightning_css.ex
@@ -16,6 +16,7 @@ defmodule Mix.Tasks.LightningCss do
 
       * `--runtime-config` - load the runtime configuration
       before executing command
+      * `--watch` - watches for file changes and re-runs Lightning CSS when any of the matched files changes.
 
   """
 
@@ -23,7 +24,7 @@ defmodule Mix.Tasks.LightningCss do
 
   @impl true
   def run(args) do
-    switches = [runtime_config: :boolean]
+    switches = [runtime_config: :boolean, watch: :boolean]
     {opts, remaining_args} = OptionParser.parse_head!(args, switches: switches)
 
     if function_exported?(Mix, :ensure_application!, 1) do
@@ -38,17 +39,17 @@ defmodule Mix.Tasks.LightningCss do
     end
 
     Mix.Task.reenable("lightning_css")
-    install_and_run(remaining_args)
+    install_and_run(remaining_args, [watch: Keyword.get(opts, :watch, false)])
   end
 
-  defp install_and_run([profile | args] = all) do
-    case LightningCSS.install_and_run(String.to_atom(profile), args) do
+  defp install_and_run([profile | args] = all, opts) do
+    case LightningCSS.install_and_run(String.to_atom(profile), args, opts) do
       0 -> :ok
       status -> Mix.raise("`mix lightning_css #{Enum.join(all, " ")}` exited with #{status}")
     end
   end
 
-  defp install_and_run([]) do
+  defp install_and_run([], _opts) do
     Mix.raise("`mix lightning_css` expects the profile as argument")
   end
 end

--- a/lib/mix/tasks/lightning_css.ex
+++ b/lib/mix/tasks/lightning_css.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.LightningCss do
   Runs lightning_css with the given profile and args.
 
   ```bash
-  $ mix lightning_css --runtime-profile dev
+  $ mix lightning_css --runtime-config dev
   ```
 
   The task will install lightning_css if it hasn't been installed previously
@@ -14,7 +14,8 @@ defmodule Mix.Tasks.LightningCss do
 
   ## Options
 
-      * `--profile` - the profile to use.
+      * `--runtime-config` - load the runtime configuration
+      before executing command
 
   """
 
@@ -22,7 +23,7 @@ defmodule Mix.Tasks.LightningCss do
 
   @impl true
   def run(args) do
-    switches = [profile: :boolean]
+    switches = [runtime_config: :boolean]
     {opts, remaining_args} = OptionParser.parse_head!(args, switches: switches)
 
     if function_exported?(Mix, :ensure_application!, 1) do
@@ -30,7 +31,7 @@ defmodule Mix.Tasks.LightningCss do
       Mix.ensure_application!(:ssl)
     end
 
-    if opts[:profile] do
+    if opts[:runtime_config] do
       Mix.Task.run("app.config")
     else
       Application.ensure_all_started(:lightning_css)

--- a/lib/mix/tasks/lightning_css.ex
+++ b/lib/mix/tasks/lightning_css.ex
@@ -33,8 +33,10 @@ defmodule Mix.Tasks.LightningCss do
     end
 
     if opts[:runtime_config] do
+      # Loads and configures all registered apps.
       Mix.Task.run("app.config")
     else
+      # Ensures that the application and their child application are started.
       Application.ensure_all_started(:lightning_css)
     end
 

--- a/lib/mix/tasks/lightning_css.install.ex
+++ b/lib/mix/tasks/lightning_css.install.ex
@@ -14,7 +14,8 @@ defmodule Mix.Tasks.LightningCss.Install do
 
   ## Options
 
-      * `--profile` - the profile to use.
+      * `--runtime-config` - load the runtime configuration
+        before executing command
 
       * `--if-missing` - install only if the given version
         does not exist
@@ -27,11 +28,11 @@ defmodule Mix.Tasks.LightningCss.Install do
 
   @impl true
   def run(args) do
-    valid_options = [profile: :boolean, if_missing: :boolean]
+    valid_options = [runtime_config: :boolean, if_missing: :boolean]
 
     case OptionParser.parse_head!(args, strict: valid_options) do
       {opts, []} ->
-        if opts[:profile], do: Mix.Task.run("app.config")
+        if opts[:runtime_config], do: Mix.Task.run("app.config")
 
         if opts[:if_missing] && latest_version?() do
           :ok
@@ -50,7 +51,7 @@ defmodule Mix.Tasks.LightningCss.Install do
         Invalid arguments to lightning_css.install, expected one of:
 
             mix lightning_css.install
-            mix lightning_css.install --profile dev
+            mix lightning_css.install --runtime_config dev
             mix lightning_css.install --if-missing
         """)
     end

--- a/lib/mix/tasks/lightning_css.install.ex
+++ b/lib/mix/tasks/lightning_css.install.ex
@@ -39,6 +39,8 @@ defmodule Mix.Tasks.LightningCss.Install do
         else
           # credo:disable-for-next-line
           if function_exported?(Mix, :ensure_application!, 1) do
+            # ensure_application! ensures that the given application and its dependencies are availble
+            # in the path
             Mix.ensure_application!(:inets)
             Mix.ensure_application!(:ssl)
           end

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule LightningCSS.MixProject do
   defp deps do
     [
       {:castore, ">= 0.0.0"},
+      {:file_system, "~> 0.2.10"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:modulex, "~> 0.7.0", runtime: false},
       {:boundary, "~> 0.10", runtime: false},


### PR DESCRIPTION
This PR adds support for watching file changes and automatically re-run Lightning CSS.
This is a feature that should ideally be supported by Lightning CSS CLI out of the box, but since it doesn't, I had to make the file watcher part of the Elixir implementation.
Note that the file-watching is quite dumb. If we get a notification, we run the CLI again