### PR TITLE
Fix watcher config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ config :my_app, MyAppWeb.Endpoint,
   # ...other attributes
   watchers: [
     # :default is the name of the profile. Update it to match yours.
-    css: {LightningCSS, :install_and_run, [:default, ~w(), watch: true]}
+    css: {LightningCSS, :install_and_run, [:default, ~w(), [watch: true]]}
   ]
 ```
 


### PR DESCRIPTION
Example config errors out due to the way opts is parsed to `LightningCSS.run/3`:
```
** (FunctionClauseError) no function clause matching in Keyword.get/3
    (elixir 1.15.7) Keyword.get({:watch, true}, :watch, false)
    (lightning_css 0.4.0) lib/lightning_css.ex:44: LightningCSS.run/3
    (phoenix 1.7.10) lib/phoenix/endpoint/watcher.ex:19: Phoenix.Endpoint.Watcher.watch/2
    (elixir 1.15.7) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
Function: &Phoenix.Endpoint.Watcher.watch/2
    Args: ["css", {LightningCSS, :install_and_run, [:default, [], {:watch, true}]}]
```
Explicitly passing `opts` as a list fixes the issue.